### PR TITLE
cblas_dcopyをcopy_nの代わりに使用

### DIFF
--- a/src/dc2_FS/FS_merge_d.hpp
+++ b/src/dc2_FS/FS_merge_d.hpp
@@ -54,7 +54,7 @@ void FS_merge_d(const Integer n, const Float d[],
         const auto row = subtree.FS_info_G1L('R', i).rocsrc;
         if (row == grid_info.myrow) {
           const auto NB1 = std::min(n, i + NB) - i;
-          std::copy_n(&d[i], NB1, &d_out[i]);
+          lapacke::copy(NB1, &d[i], 1, &d_out[i], 1);
         }
       }
     }
@@ -71,7 +71,7 @@ void FS_merge_d(const Integer n, const Float d[],
         const auto col = subtree.FS_info_G1L('C', j).rocsrc;
         if (col == grid_info.mycol) {
           const auto NB1 = std::min(n, j + NB) - j;
-          std::copy_n(&d[j], NB1, &d_out[j]);
+          lapacke::copy(NB1, &d[j], 1, &d_out[j], 1);
         }
       }
     }

--- a/src/dc2_FS/FS_pdlaed2.hpp
+++ b/src/dc2_FS/FS_pdlaed2.hpp
@@ -332,11 +332,11 @@ FS_pdlaed2(const Integer n, const Integer n1, Float d[], Float q[],
         const auto jjs = subtree.FS_index_G2L('C', js);
         const auto i = indx[j];
         const auto jjq2 = subtree.FS_index_G2L('C', i);
-        std::copy_n(&q[jjs * ldq], npa, &q2[jjq2 * ldq2]);
+        lapacke::copy(npa, &q[jjs * ldq], 1, &q2[jjq2 * ldq2], 1);
       }
     }
 
-    std::copy_n(d, n, z);
+    lapacke::copy(n, d, 1, z, 1);
 #pragma omp parallel for
     for (Integer j = k; j < n; j++) {
       const auto js = indxp[j];

--- a/src/dc2_FS/FS_pdlaed3.hpp
+++ b/src/dc2_FS/FS_pdlaed3.hpp
@@ -411,7 +411,7 @@ Integer FS_pdlaed3(const Integer k, const Integer n, const Integer n1,
 #pragma omp parallel for
           for (Integer jq2 = 0; jq2 < n12; jq2++) {
             const auto js = jq2 * np1;
-            std::copy_n(&recvq2[js], np1, &q2[jq2 * ldq2 + 0]);
+            lapacke::copy(np1, &recvq2[js], 1, &q2[jq2 * ldq2 + 0], 1);
           }
         }
         // 下側
@@ -420,7 +420,7 @@ Integer FS_pdlaed3(const Integer k, const Integer n, const Integer n1,
           for (Integer j = 0; j < n23; j++) {
             const auto jq2 = j + ctot[0 * lctot + pjcol];
             const auto js = n12 * np1 + j * np2;
-            std::copy_n(&recvq2[js], np2, &q2[jq2 * ldq2 + np1]);
+            lapacke::copy(np2, &recvq2[js], 1, &q2[jq2 * ldq2 + np1], 1);
           }
         }
 
@@ -456,7 +456,7 @@ Integer FS_pdlaed3(const Integer k, const Integer n, const Integer n1,
 #pragma omp parallel for
             for (Integer jq2 = 0; jq2 < n12; jq2++) {
               const auto js = jq2 * np1;
-              std::copy_n(&q2[jq2 * ldq2 + 0], np1, &sendq2[js]);
+              lapacke::copy(np1, &q2[jq2 * ldq2 + 0], 1, &sendq2[js], 1);
             }
           }
           // 下側
@@ -465,7 +465,7 @@ Integer FS_pdlaed3(const Integer k, const Integer n, const Integer n1,
             for (Integer j = 0; j < n23; j++) {
               const auto jq2 = j + ctot[0 * lctot + pjcol];
               const auto js = n12 * np1 + j * np2;
-              std::copy_n(&q2[jq2 * ldq2 + np1], np2, &sendq2[js]);
+              lapacke::copy(np2, &q2[jq2 * ldq2 + np1], 1, &sendq2[js], 1);
             }
           }
         }

--- a/src/dc2_FS/FS_pdlasrt.hpp
+++ b/src/dc2_FS/FS_pdlasrt.hpp
@@ -97,7 +97,8 @@ void FS_pdlasrt(const Integer n, Float d[], Float q[], const Integer ldq,
         const auto jl = subtree.FS_index_G2L('C', gi);
 
         // 送信バッファに格納
-        std::copy_n(&q[jl * ldq], np, &sendq[nsend * np]);
+
+        lapacke::copy(np, &q[jl * ldq], 1, &sendq[nsend * np], 1);
         nsend += 1;
       }
 
@@ -133,7 +134,7 @@ void FS_pdlasrt(const Integer n, Float d[], Float q[], const Integer ldq,
 #pragma omp parallel for
       for (Integer j = 0; j < nrecv; j++) {
         const auto jl = indrcv[j];
-        std::copy_n(&recvq[j * np], np, &q2[jl * ldq2]);
+        lapacke::copy(np, &recvq[j * np], 1, &q2[jl * ldq2], 1);
       }
     }
   }


### PR DESCRIPTION
std::copy_nよりもcblasのdcopyの方がより高速に動作する